### PR TITLE
fix: use correct -m flag for CivitAI model downloads

### DIFF
--- a/download_handler.py
+++ b/download_handler.py
@@ -46,7 +46,7 @@ def _download_civitai(version_id: str, dest_dir: str) -> dict:
     before = set(os.listdir(dest_dir)) if os.path.isdir(dest_dir) else set()
 
     result = subprocess.run(
-        ["python3", CIVITAI_SCRIPT, "-v", str(version_id), "-o", dest_dir],
+        ["python3", CIVITAI_SCRIPT, "-m", str(version_id), "-o", dest_dir],
         capture_output=True,
         text=True,
         timeout=600,


### PR DESCRIPTION
The `download_with_aria.py` script requires `-m/--model-id` for the model version ID, not `-v`. This was causing CivitAI downloads to fail with:

    "error: the following arguments are required: -m/--model-id"

Changed subprocess call in `_download_civitai()` from `-v` to `-m` flag to match the expected argument format of `download_with_aria.py`.

Fixes #1 